### PR TITLE
Fixed RCE on easy-pdf-merge

### DIFF
--- a/source/lib/PDFMerger.js
+++ b/source/lib/PDFMerger.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').exec;
+const exec = require('child_process').execFile;
 const path = require('path');
 
 function checkSrc(src, callback) {
@@ -63,8 +63,8 @@ module.exports = function (src, dest, opts, callback) {
     command.push(`"${dest}"`);
 
     delete opts.maxHeap;
-
-    const child = exec(command.join(' '), opts, function (err, stdout, stderr) {
+    command = command.join(' ').split(' ');
+    const child = exec(command[0], command.slice(1), opts, function (err, stdout, stderr) {
       if (err) {
         return callback(err);
       }


### PR DESCRIPTION
### 📊 Metadata *

Remote code execution vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-easy-pdf-merge

### ⚙️ Description *

The `easy-pdf-merge module` is vulnerable against RCE since user supplied inputs are formatted inside a command which is executed without prior checks. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```javascript
const merge = require('easy-pdf-merge');

merge(["test", "test1"], "test2", {maxHeap:"test; touch HACKED; #"}, function(err){
  if(err) {
    return console.log(err)
  }
  console.log('Success')
});

```
A file named `HACKED` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92493051-b13aad80-f211-11ea-8d25-2745d2128a4d.png)



### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92493168-d0393f80-f211-11ea-9151-e8a78426987d.png)



### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
